### PR TITLE
Dalenard21 patch 1

### DIFF
--- a/_data/unique-hiring-paths.yml
+++ b/_data/unique-hiring-paths.yml
@@ -115,7 +115,7 @@ native-americans:
 
 peace-corps:
   title: "Peace Corps & AmeriCorps VISTA"
-  text: "If you served with the Peace Corps or AmeriCorps VISTA, you may qualify for non-competitive eligibility. This means that a federal agency can hire you outside of the formal competitive job announcement process."
+  text: "If you served with the Peace Corps or AmeriCorps VISTA as a volunteer or volunteer leader, you may qualify for non-competitive eligibility. This means that a federal agency can hire you outside of the usual competitive examining process."
   subtext: Individuals who have served at least 2 years with the Peace Corps or 1 year with AmeriCorps VISTA.
   image-alt: "One individual helps another up a mountain."
   icon: peace-corps

--- a/working-in-government/unique-hiring-paths/peace-corps/index.html
+++ b/working-in-government/unique-hiring-paths/peace-corps/index.html
@@ -17,7 +17,7 @@ short-name: peace-corps
   </div>
   <div class="usajobs-uhp-section__col-right">
     <p>
-      You’re eligible if you have at least two years of service with the Peace Corps or one year of service with AmeriCorps VISTA.
+      You’re eligible if your service as a volunteer or volunteer leader totals at least 1 year with the Peace Corps or one year of service with AmeriCorps VISTA.
     </p>
     <p>
       Your non-competitive eligibility lasts for one year after completing your Peace Corps or AmeriCorps service. Federal agencies may extend the period for up to three years if, after your completed service, you are:


### PR DESCRIPTION
1. Updated the text on the Peace Corps/Americorp hiring path banner to read:

If you served with the Peace Corps or AmeriCorps VISTA as a volunteer or volunteer leader, you may qualify for non-competitive eligibility. This means that a federal agency can hire you outside of the usual competitive examining process.

2. Updated the Peace Corps/AmeriCorps hiring path eligibility content to read: 

You’re eligible if your service as a volunteer or volunteer leader totals at least 1 year with the Peace Corps or one year of service with AmeriCorps VISTA.