### PR TITLE
Updates to file size in two help center pages - Dalenard21 patch 4

### DIFF
--- a/how-to/account/documents/index.md
+++ b/how-to/account/documents/index.md
@@ -35,7 +35,7 @@ You can make your resume searchable, so your profile and resume will be visible 
 
 ### Upload a resume or create a resume
 
-You can [upload a resume](resume/upload/) or [use our Resume Builder to build one](resume/build/). Resumes must be less than 3MB in size. You can upload in the following formats:
+You can [upload a resume](resume/upload/) or [use our Resume Builder to build one](resume/build/). Resumes can be no larger than 5MB in size. You can upload in the following formats:
 
 * GIF
 * JPG
@@ -67,4 +67,4 @@ All documents must be less than 3MB in size and in one of the following document
 
 If you make changes to a document, you'll need to upload the updated version of the file to your profile.  However, some forms can’t be edited, except for the file name or document type.
 
-[How do I upload a document that's larger than 3MB](upload/#how-do-I-upload-a-document-that's-larger-than-3MB)?
+[How do I upload a document that's larger than 5MB](upload/#how-do-I-upload-a-document-that's-larger-than-3MB)?

--- a/how-to/account/documents/upload.md
+++ b/how-to/account/documents/upload.md
@@ -25,7 +25,7 @@ The uploaded document will appear in your account in the **Other Documents** sec
 
 ## Document Size and Format
 
-All documents must be less than 3MB in size, cannot be encrypted and must be in one of the following formats:
+All documents must be less than 5MB in size, cannot be encrypted and must be in one of the following formats:
 
 * GIF
 * JPG
@@ -36,9 +36,9 @@ All documents must be less than 3MB in size, cannot be encrypted and must be in 
 * TXT
 * Word (.doc or .docx)
 
-### How do I upload a document that's larger than 3MB?
+### How do I upload a document that's larger than 5MB?
 
-If your document is larger than 3 MB, here are some suggestions:
+If your document is larger than 5MB, here are some suggestions:
 
 * Read Adobe’s tutorial on [how to reduce PDF file size](https://acrobatusers.com/tutorials/reducing-file-size){:target="_blank"}.
 * Print your document, scan it (if you have a personal scanner) and save it at a smaller size.


### PR DESCRIPTION
Updated the following pages, changing file size 3MB to 5MB to support seeker portal change of allowing documents up to 5MB.

https://github.com/USAJOBS/Help/blob/dalenard21-patch-4/how-to/account/documents/index.md

https://github.com/USAJOBS/Help/blob/dalenard21-patch-4/how-to/account/documents/upload.md